### PR TITLE
Add prefix match style to constant ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `prefix_match` option to ComponentClient custom ids to make storing metadata in custom ids
+  possible.
 
-## [1.0.3a1]
+### Fixed
+- custom id methods now raise ValueError on conflict rather than KeyError.
+
+## [1.0.3a1] - 2021-10-27
 ### Added
 - An ASGI/3 adapter for Hikari's interaction server.
 - Ability to register a callback for a constant custom_id in the component client.

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -142,6 +142,41 @@ class TestComponentClient:
 
         assert result is client
         assert client.get_constant_id("123") is mock_callback
+        assert client._constant_ids["123"] is mock_callback
+        assert "123" not in client._prefix_ids
+
+    def test_set_constant_id_when_already_present_as_custom_id(self):
+        mock_callback = mock.Mock()
+        client = yuyo.ComponentClient().set_constant_id("trans", mock_callback)
+
+        with pytest.raises(ValueError, match="'trans' is already registered as a constant id"):
+            client.set_constant_id("trans", mock.Mock())
+
+        assert client.get_constant_id("trans") is mock_callback
+        assert client._constant_ids["trans"] is mock_callback
+        assert "trans" not in client._prefix_ids
+
+    def test_set_constant_id_when_already_present_as_prefix_id(self):
+        mock_callback = mock.Mock()
+        client = yuyo.ComponentClient().set_constant_id("trans2", mock_callback, prefix_match=True)
+
+        with pytest.raises(ValueError, match="'trans2' is already registered as a prefix match"):
+            client.set_constant_id("trans2", mock.Mock())
+
+        assert client.get_constant_id("trans2") is mock_callback
+        assert "trans2" not in client._constant_ids
+        assert client._prefix_ids["trans2"] is mock_callback
+
+    def test_set_constant_id_when_prefix_match(self):
+        mock_callback = mock.Mock()
+        client = yuyo.ComponentClient()
+
+        result = client.set_constant_id("456", mock_callback, prefix_match=True)
+
+        assert result is client
+        assert client.get_constant_id("456") is mock_callback
+        assert "456" not in client._constant_ids
+        assert client._prefix_ids["456"] is mock_callback
 
     def test_remove_constant_id(self):
         client = yuyo.ComponentClient().set_constant_id("yuri", mock.Mock())
@@ -150,6 +185,31 @@ class TestComponentClient:
 
         assert result is client
         assert client.get_constant_id("yuri") is None
+        assert "yuri" not in client._constant_ids
+        assert "yuri" not in client._prefix_ids
+
+    def test_remove_constant_id_for_prefix_id(self):
+        client = yuyo.ComponentClient().set_constant_id("yuro", mock.Mock(), prefix_match=True)
+
+        result = client.remove_constant_id("yuro")
+
+        assert result is client
+        assert client.get_constant_id("yuro") is None
+        assert "yuro" not in client._constant_ids
+        assert "yuro" not in client._prefix_ids
+
+    def test_remove_constant_id_when_not_present(self):
+        client = (
+            yuyo.ComponentClient()
+            .set_constant_id("e", mock.Mock())
+            .set_constant_id("h", mock.Mock(), prefix_match=True)
+        )
+
+        with pytest.raises(KeyError):
+            client.remove_constant_id("yuri")
+
+        assert "e" in client._constant_ids
+        assert "h" in client._prefix_ids
 
     def test_with_constant_id(self):
         mock_callback = mock.Mock()
@@ -158,6 +218,40 @@ class TestComponentClient:
         result = client.with_constant_id("yuri")(mock_callback)
 
         assert result is mock_callback
+        assert client._constant_ids["yuri"] is mock_callback
+        assert "yuri" not in client._prefix_ids
+
+    def test_with_constant_id_when_prefix_match(self):
+        mock_callback = mock.Mock()
+        client = yuyo.ComponentClient()
+
+        result = client.with_constant_id("yuru", prefix_match=True)(mock_callback)
+
+        assert result is mock_callback
+        assert "yuru" not in client._constant_ids
+        assert client._prefix_ids["yuru"] is mock_callback
+
+    def test_with_constant_id_when_already_present_as_custom_id(self):
+        mock_callback = mock.Mock()
+        client = yuyo.ComponentClient().set_constant_id("trans", mock_callback)
+
+        with pytest.raises(ValueError, match="'trans' is already registered as a constant id"):
+            client.with_constant_id("trans")(mock.Mock())
+
+        assert client.get_constant_id("trans") is mock_callback
+        assert client._constant_ids["trans"] is mock_callback
+        assert "trans" not in client._prefix_ids
+
+    def test_with_constant_id_when_already_present_as_prefix_id(self):
+        mock_callback = mock.Mock()
+        client = yuyo.ComponentClient().set_constant_id("trans2", mock_callback, prefix_match=True)
+
+        with pytest.raises(ValueError, match="'trans2' is already registered as a prefix match"):
+            client.with_constant_id("trans2")(mock.Mock())
+
+        assert client.get_constant_id("trans2") is mock_callback
+        assert "trans2" not in client._constant_ids
+        assert client._prefix_ids["trans2"] is mock_callback
 
     def test_add_executor(self):
         mock_executor = mock.Mock()


### PR DESCRIPTION
### Summary
Add prefix match style to custom ids

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
