### PR TITLE
Fix handling of defaulting empty modal text inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [yuyo.modals.modal][] and [yuyo.modals.as_modal][] no-longer lead to Alluka's type-hint introspection
   raising an exception.
+- Handling of defaulting empty modal text inputs.
 
 ## [1.9.0a1] - 2023-02-27
 ### Added

--- a/yuyo/modals.py
+++ b/yuyo/modals.py
@@ -1229,7 +1229,7 @@ class Modal(AbstractModal):
 
             # Discord still provides text components when no input was given just with
             # an empty string for `value` but we also want to support possible future
-            # cases where they just just don't provide the component. 
+            # cases where they just just don't provide the component.
             if not component or not component.value:
                 if field.default is NO_DEFAULT:
                     raise RuntimeError(f"Missing required component `{field.custom_id}`")

--- a/yuyo/modals.py
+++ b/yuyo/modals.py
@@ -1227,7 +1227,10 @@ class Modal(AbstractModal):
             else:
                 component = components.get(field.custom_id)
 
-            if not component:
+            # Discord still provides text components when no input was given just with
+            # an empty string for `value` but we also want to support possible future
+            # cases where they just just don't provide the component. 
+            if not component or not component.value:
                 if field.default is NO_DEFAULT:
                     raise RuntimeError(f"Missing required component `{field.custom_id}`")
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
