### PR TITLE
Use text_input `default` for `value` when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [ComponentContext.select_members][yuyo.components.ComponentContext.select_members].
 - The [yuyo.components.Context][] and [yuyo.modals.Context][] aliases.
 
+### Changed
+- A Modal text input's `default` will now also be used for `value` when `value` is left undefined and
+  `default` is a string of `<=4000` characters.
+
 ## [1.10.0a1] - 2023-03-20
 ### Added
 - Support for declaring modal options in the modal callback's signature.

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -339,6 +339,85 @@ class TestModal:
         assert field.prefix_match is True
         assert field.type is hikari.ComponentType.TEXT_INPUT
 
+    @pytest.mark.parametrize("default", ["meep", "x" * 4000, "a"])
+    def test_with_text_input_descriptor_uses_string_default_as_value(self, default: str):
+        @modals.as_modal_template()
+        async def modal_template(
+            ctx: modals.ModalContext,
+            a_field: typing.Union[str, int] = modals.text_input(
+                "bababooi",
+                default=default
+            ),
+        ) -> None:
+            ...
+
+        modal = modal_template()
+
+        assert len(modal.rows) == 1
+        row = modal.rows[0]
+        assert len(row.components) == 1
+        component = row.components[0]
+        assert isinstance(component, hikari.api.TextInputBuilder)
+        assert component.value == default
+        assert component.required is False  # TODO: rename to is_required
+
+        assert len(modal._tracked_fields) == 1
+        field = modal._tracked_fields[0]
+        assert isinstance(field, modals._TrackedField)
+        assert field.default == default
+
+    def test_with_text_input_descriptor_with_non_str_default(self):
+        @modals.as_modal_template()
+        async def modal_template(
+            ctx: modals.ModalContext,
+            a_field: typing.Union[str, int] = modals.text_input(
+                "bababooi",
+                default=123
+            ),
+        ) -> None:
+            ...
+
+        modal = modal_template()
+
+        assert len(modal.rows) == 1
+        row = modal.rows[0]
+        assert len(row.components) == 1
+        component = row.components[0]
+        assert isinstance(component, hikari.api.TextInputBuilder)
+        assert component.value is hikari.UNDEFINED
+        assert component.required is False  # TODO: rename to is_required
+
+        assert len(modal._tracked_fields) == 1
+        field = modal._tracked_fields[0]
+        assert isinstance(field, modals._TrackedField)
+        assert field.default == 123
+
+    def test_with_text_input_descriptor_when_string_default_over_4000_chars(self):
+        @modals.as_modal_template()
+        async def modal_template(
+            ctx: modals.ModalContext,
+            a_field: typing.Union[str, int] = modals.text_input(
+                "bababooi",
+                default="x" * 4001
+            ),
+        ) -> None:
+            ...
+
+        modal = modal_template()
+
+        assert len(modal.rows) == 1
+        row = modal.rows[0]
+        assert len(row.components) == 1
+        component = row.components[0]
+        assert isinstance(component, hikari.api.TextInputBuilder)
+        assert component.value is hikari.UNDEFINED
+        assert component.required is False  # TODO: rename to is_required
+
+        assert len(modal._tracked_fields) == 1
+        field = modal._tracked_fields[0]
+        assert isinstance(field, modals._TrackedField)
+        assert field.default == "x" * 4001
+
     def test_with_text_input_descriptor_when_not_prefix_matched(self):
         @modals.as_modal_template()
         async def modal_template(

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -343,11 +343,7 @@ class TestModal:
     def test_with_text_input_descriptor_uses_string_default_as_value(self, default: str):
         @modals.as_modal_template()
         async def modal_template(
-            ctx: modals.ModalContext,
-            a_field: typing.Union[str, int] = modals.text_input(
-                "bababooi",
-                default=default
-            ),
+            ctx: modals.ModalContext, a_field: typing.Union[str, int] = modals.text_input("bababooi", default=default)
         ) -> None:
             ...
 
@@ -369,11 +365,7 @@ class TestModal:
     def test_with_text_input_descriptor_with_non_str_default(self):
         @modals.as_modal_template()
         async def modal_template(
-            ctx: modals.ModalContext,
-            a_field: typing.Union[str, int] = modals.text_input(
-                "bababooi",
-                default=123
-            ),
+            ctx: modals.ModalContext, a_field: typing.Union[str, int] = modals.text_input("bababooi", default=123)
         ) -> None:
             ...
 
@@ -396,10 +388,7 @@ class TestModal:
         @modals.as_modal_template()
         async def modal_template(
             ctx: modals.ModalContext,
-            a_field: typing.Union[str, int] = modals.text_input(
-                "bababooi",
-                default="x" * 4001
-            ),
+            a_field: typing.Union[str, int] = modals.text_input("bababooi", default="x" * 4001),
         ) -> None:
             ...
 

--- a/yuyo/modals.py
+++ b/yuyo/modals.py
@@ -1093,6 +1093,9 @@ class Modal(AbstractModal):
             Default value to pass if this text input field was not provided.
 
             The field will be marked as required unless this is supplied.
+
+            This will also be used for `value` when it has been left undefined
+            and the default is a string that's <=4000 characters in length.
         min_length
             Minimum length the input text can be.
 
@@ -1134,7 +1137,7 @@ class Modal(AbstractModal):
             label=label,
             style=style,
             placeholder=placeholder,
-            value=value,
+            value=_workout_value(default, value),
             default=default,
             min_length=min_length,
             max_length=max_length,
@@ -1190,6 +1193,9 @@ class Modal(AbstractModal):
             Default value to pass if this text input field was not provided.
 
             The field will be marked as required unless this is supplied.
+
+            This will also be used for `value` when it has been left undefined
+            and the default is a string that's <=4000 characters in length.
         min_length
             Minimum length the input text can be.
 
@@ -1222,7 +1228,7 @@ class Modal(AbstractModal):
             label=label,
             style=style,
             placeholder=placeholder,
-            value=value,
+            value=_workout_value(default, value),
             default=default,
             min_length=min_length,
             max_length=max_length,
@@ -1257,6 +1263,16 @@ class Modal(AbstractModal):
 
         fields = {field.parameter: field.process(compiled_prefixes, components) for field in self._tracked_fields}
         await ctx.client.alluka.call_with_async_di(self.callback, ctx, **fields)
+
+
+def _workout_value(default: typing.Any, value: hikari.UndefinedOr[str]) -> hikari.UndefinedOr[str]:
+    if value is not hikari.UNDEFINED or default is hikari.UNDEFINED:
+        return value
+
+    if isinstance(default, str) and len(default) <= 4000:
+        return default
+
+    return value
 
 
 def _make_text_input(
@@ -1496,6 +1512,9 @@ def with_static_text_input(
         Default value to pass if this text input field was not provided.
 
         The field will be marked as required unless this is supplied.
+
+        This will also be used for `value` when it has been left undefined
+        and the default is a string that's <=4000 characters in length.
     min_length
         Minimum length the input text can be.
 
@@ -1573,6 +1592,9 @@ def with_text_input(
         Default value to pass if this text input field was not provided.
 
         The field will be marked as required unless this is supplied.
+
+        This will also be used for `value` when it has been left undefined
+        and the default is a string that's <=4000 characters in length.
     min_length
         Minimum length the input text can be.
 
@@ -1804,6 +1826,9 @@ def text_input(
         Default value to pass if this text input field was not provided.
 
         The field will be marked as required unless this is supplied.
+
+        This will also be used for `value` when it has been left undefined
+        and the default is a string that's <=4000 characters in length.
     min_length
         Minimum length the input text can be.
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
