### PR TITLE
Mark timeout class aliases as deprecated using typing.deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed `yuyo.timeouts.BasicTimeout` to [yuyo.timeouts.SlidingTimeout][].
+- Marked deprecated timeout class aliases using `typing.deprecated`.
 
 ### [1.10.1a1] - 2023-03-25
 ### Added

--- a/yuyo/__init__.py
+++ b/yuyo/__init__.py
@@ -72,6 +72,7 @@ __all__: list[str] = [
     "sync_paginate_string",
     "timeouts",
     "to_builder",
+    "StaticTimeout",
 ]
 
 from . import links
@@ -104,5 +105,6 @@ from .pagination import sync_paginate_string
 from .reactions import ReactionClient
 from .reactions import ReactionHandler
 from .reactions import ReactionPaginator
-from .timeouts import BasicTimeout
+from .timeouts import BasicTimeout  # pyright: ignore [ reportDeprecated ]
 from .timeouts import SlidingTimeout
+from .timeouts import StaticTimeout

--- a/yuyo/__init__.py
+++ b/yuyo/__init__.py
@@ -56,6 +56,7 @@ __all__: list[str] = [
     "ServiceManager",
     "ShardFinishedChunkingEvent",
     "SlidingTimeout",
+    "StaticTimeout",
     "TopGGService",
     "WaitForExecutor",
     "aenumerate",
@@ -72,7 +73,6 @@ __all__: list[str] = [
     "sync_paginate_string",
     "timeouts",
     "to_builder",
-    "StaticTimeout",
 ]
 
 from . import links

--- a/yuyo/modals.py
+++ b/yuyo/modals.py
@@ -89,7 +89,7 @@ class AbstractTimeout(timeouts.AbstractTimeout):
     __slots__ = ()
 
 
-@typing_extensions.deprecated("Use yuyo.timeouts.BasicTimeout")
+@typing_extensions.deprecated("Use yuyo.timeouts.SlidingTimeout")
 class BasicTimeout(timeouts.SlidingTimeout):
     """Deprecated alias of [yuyo.timeouts.SlidingTimeout][]."""
 

--- a/yuyo/modals.py
+++ b/yuyo/modals.py
@@ -81,14 +81,26 @@ _CoroT = collections.abc.Coroutine[typing.Any, typing.Any, _T]
 _ModalResponseT = typing.Union[hikari.api.InteractionMessageBuilder, hikari.api.InteractionDeferredBuilder]
 """Type hint of the builder response types allows for modal interactions."""
 
-AbstractTimeout = timeouts.AbstractTimeout
-"""Deprecated alias of [yuyo.timeouts.AbstractTimeout][]."""
 
-BasicTimeout = timeouts.SlidingTimeout
-"""Deprecated alias of [yuyo.timeouts.SlidingTimeout][]."""
+@typing_extensions.deprecated("Use yuyo.timeouts.AbstractTimeout")
+class AbstractTimeout(timeouts.AbstractTimeout):
+    """Deprecated alias of [yuyo.timeouts.AbstractTimeout][]."""
 
-NeverTimeout = timeouts.NeverTimeout
-"""Deprecated alias of [yuyo.timeouts.NeverTimeout][]."""
+    __slots__ = ()
+
+
+@typing_extensions.deprecated("Use yuyo.timeouts.BasicTimeout")
+class BasicTimeout(timeouts.SlidingTimeout):
+    """Deprecated alias of [yuyo.timeouts.SlidingTimeout][]."""
+
+    __slots__ = ()
+
+
+@typing_extensions.deprecated("Use yuyo.timeouts.NeverTimeout")
+class NeverTimeout(timeouts.NeverTimeout):
+    """Deprecated alias of [yuyo.timeouts.NeverTimeout][]."""
+
+    __slots__ = ()
 
 
 class _NoDefaultEnum(enum.Enum):

--- a/yuyo/timeouts.py
+++ b/yuyo/timeouts.py
@@ -36,6 +36,7 @@ __all__ = ["BasicTimeout", "NeverTimeout", "SlidingTimeout", "StaticTimeout"]
 import abc
 import datetime
 import typing
+import typing_extensions
 
 
 class AbstractTimeout(abc.ABC):
@@ -107,8 +108,11 @@ class SlidingTimeout(AbstractTimeout):
         return self._uses_left == 0
 
 
-BasicTimeout = SlidingTimeout
-"""Deprecated alias of [SlidingTimeout][yuyo.timeouts.SlidingTimeout]."""
+@typing_extensions.deprecated("Use yuyo.timeouts.SlidingTimeout")
+class BasicTimeout(SlidingTimeout):
+    """Deprecated alias of [SlidingTimeout][yuyo.timeouts.SlidingTimeout]."""
+
+    __slots__ = ()
 
 
 class NeverTimeout(AbstractTimeout):

--- a/yuyo/timeouts.py
+++ b/yuyo/timeouts.py
@@ -36,6 +36,7 @@ __all__ = ["BasicTimeout", "NeverTimeout", "SlidingTimeout", "StaticTimeout"]
 import abc
 import datetime
 import typing
+
 import typing_extensions
 
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
