### PR TITLE
Don't subclass AbstractTimeout to mark as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed `yuyo.timeouts.BasicTimeout` to [yuyo.timeouts.SlidingTimeout][].
-- Marked deprecated timeout class aliases using `typing.deprecated`.
+- Marked most deprecated timeout class aliases using `typing.deprecated`.
+  (only `yuyo.modals.AbstractTimeout` was skipped).
 
 ### [1.10.1a1] - 2023-03-25
 ### Added

--- a/yuyo/modals.py
+++ b/yuyo/modals.py
@@ -82,11 +82,8 @@ _ModalResponseT = typing.Union[hikari.api.InteractionMessageBuilder, hikari.api.
 """Type hint of the builder response types allows for modal interactions."""
 
 
-@typing_extensions.deprecated("Use yuyo.timeouts.AbstractTimeout")
-class AbstractTimeout(timeouts.AbstractTimeout):
-    """Deprecated alias of [yuyo.timeouts.AbstractTimeout][]."""
-
-    __slots__ = ()
+AbstractTimeout = timeouts.AbstractTimeout
+"""Deprecated alias of [yuyo.timeouts.AbstractTimeout][]."""
 
 
 @typing_extensions.deprecated("Use yuyo.timeouts.SlidingTimeout")


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
